### PR TITLE
✨  Feat : grade 컴포넌트 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-scripts": "5.0.0",
     "styled-components": "^5.3.3",
     "styled-reset": "^4.3.4",

--- a/src/components/Grade.jsx
+++ b/src/components/Grade.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { BsStarFill, BsStar } from 'react-icons/bs';
+// import ReviewTitle from './ReviewTitle';
+// import styled from 'styled-components';
+const Grade = () => {
+  const [clicked, setClicked] = useState([false, false, false, false, false]);
+
+  const handleStarClick = (e, index) => {
+    e.preventDefault();
+    let clickStates = [...clicked];
+    for (let i = 0; i < 5; i++) {
+      if (i <= index) clickStates[i] = true;
+      else clickStates[i] = false;
+    }
+
+    setClicked(clickStates);
+  };
+
+  console.log(clicked);
+
+  return (
+    <div>
+      <p>Rating</p>
+      <div>
+        {clicked[0] ? (
+          <BsStarFill onClick={e => handleStarClick(e, 0)} />
+        ) : (
+          <BsStar onClick={e => handleStarClick(e, 0)} />
+        )}
+        {clicked[1] ? (
+          <BsStarFill onClick={e => handleStarClick(e, 1)} />
+        ) : (
+          <BsStar onClick={e => handleStarClick(e, 1)} />
+        )}
+        {clicked[2] ? (
+          <BsStarFill onClick={e => handleStarClick(e, 2)} />
+        ) : (
+          <BsStar onClick={e => handleStarClick(e, 2)} />
+        )}
+        {clicked[3] ? (
+          <BsStarFill onClick={e => handleStarClick(e, 3)} />
+        ) : (
+          <BsStar onClick={e => handleStarClick(e, 3)} />
+        )}
+        {clicked[4] ? (
+          <BsStarFill onClick={e => handleStarClick(e, 4)} />
+        ) : (
+          <BsStar onClick={e => handleStarClick(e, 4)} />
+        )}
+      </div>
+    </div>
+  );
+};
+// const GradeContainer = styled.div`
+//   width: 500px;
+//   margin: 10px;
+// `;
+
+// const BsStarContainer = styled.div`
+//   display: flex;
+//   justify-content: center;
+// `;
+
+// const BsStarMargin = styled.div`
+//   margin: 0px 3px;
+// `;
+
+export default Grade;

--- a/src/components/Grade.jsx
+++ b/src/components/Grade.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { FaStar } from 'react-icons/fa';
 import styled from 'styled-components';
-
+import ReviewTitle from './ReviewTitle';
 const ARRAY = [0, 1, 2, 3, 4];
 
 function Grade() {
@@ -17,7 +17,7 @@ function Grade() {
 
   return (
     <Wrap>
-      <RatingText>평가하기</RatingText>
+      <ReviewTitle title={'평점'} />
       <Stars>
         {ARRAY.map((el, idx) => {
           return (
@@ -39,18 +39,14 @@ export default Grade;
 const Wrap = styled.div`
   display: flex;
   flex-direction: column;
-  padding-top: 15px;
-`;
-
-const RatingText = styled.div`
-  color: #787878;
-  font-size: 12px;
-  font-weight: 400;
+  width: 500px;
+  margin: auto;
 `;
 
 const Stars = styled.div`
   display: flex;
-  padding-top: 5px;
+  margin: 10px;
+  justify-content: center;
 
   & svg {
     color: gray;

--- a/src/components/Grade.jsx
+++ b/src/components/Grade.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { BsStarFill, BsStar } from 'react-icons/bs';
-// import ReviewTitle from './ReviewTitle';
-// import styled from 'styled-components';
+import ReviewTitle from './ReviewTitle';
+import styled from 'styled-components';
 const Grade = () => {
   const [clicked, setClicked] = useState([false, false, false, false, false]);
 
@@ -19,50 +19,60 @@ const Grade = () => {
   console.log(clicked);
 
   return (
-    <div>
-      <p>Rating</p>
-      <div>
-        {clicked[0] ? (
-          <BsStarFill onClick={e => handleStarClick(e, 0)} />
-        ) : (
-          <BsStar onClick={e => handleStarClick(e, 0)} />
-        )}
-        {clicked[1] ? (
-          <BsStarFill onClick={e => handleStarClick(e, 1)} />
-        ) : (
-          <BsStar onClick={e => handleStarClick(e, 1)} />
-        )}
-        {clicked[2] ? (
-          <BsStarFill onClick={e => handleStarClick(e, 2)} />
-        ) : (
-          <BsStar onClick={e => handleStarClick(e, 2)} />
-        )}
-        {clicked[3] ? (
-          <BsStarFill onClick={e => handleStarClick(e, 3)} />
-        ) : (
-          <BsStar onClick={e => handleStarClick(e, 3)} />
-        )}
-        {clicked[4] ? (
-          <BsStarFill onClick={e => handleStarClick(e, 4)} />
-        ) : (
-          <BsStar onClick={e => handleStarClick(e, 4)} />
-        )}
-      </div>
-    </div>
+    <GradeContainer>
+      <ReviewTitle />
+      <BsStarContainer>
+        <BsStarMargin>
+          {clicked[0] ? (
+            <BsStarFill onClick={e => handleStarClick(e, 0)} />
+          ) : (
+            <BsStar onClick={e => handleStarClick(e, 0)} />
+          )}
+        </BsStarMargin>
+        <BsStarMargin>
+          {clicked[1] ? (
+            <BsStarFill onClick={e => handleStarClick(e, 1)} />
+          ) : (
+            <BsStar onClick={e => handleStarClick(e, 1)} />
+          )}
+        </BsStarMargin>
+        <BsStarMargin>
+          {clicked[2] ? (
+            <BsStarFill onClick={e => handleStarClick(e, 2)} />
+          ) : (
+            <BsStar onClick={e => handleStarClick(e, 2)} />
+          )}
+        </BsStarMargin>
+        <BsStarMargin>
+          {clicked[3] ? (
+            <BsStarFill onClick={e => handleStarClick(e, 3)} />
+          ) : (
+            <BsStar onClick={e => handleStarClick(e, 3)} />
+          )}
+        </BsStarMargin>
+        <BsStarMargin>
+          {clicked[4] ? (
+            <BsStarFill onClick={e => handleStarClick(e, 4)} />
+          ) : (
+            <BsStar onClick={e => handleStarClick(e, 4)} />
+          )}
+        </BsStarMargin>
+      </BsStarContainer>
+    </GradeContainer>
   );
 };
-// const GradeContainer = styled.div`
-//   width: 500px;
-//   margin: 10px;
-// `;
+const GradeContainer = styled.div`
+  width: 500px;
+  margin: 10px;
+`;
 
-// const BsStarContainer = styled.div`
-//   display: flex;
-//   justify-content: center;
-// `;
+const BsStarContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
 
-// const BsStarMargin = styled.div`
-//   margin: 0px 3px;
-// `;
+const BsStarMargin = styled.div`
+  margin: 0px 3px;
+`;
 
 export default Grade;

--- a/src/components/Grade.jsx
+++ b/src/components/Grade.jsx
@@ -1,78 +1,71 @@
 import React, { useState } from 'react';
-import { BsStarFill, BsStar } from 'react-icons/bs';
-import ReviewTitle from './ReviewTitle';
+import { FaStar } from 'react-icons/fa';
 import styled from 'styled-components';
-const Grade = () => {
+
+const ARRAY = [0, 1, 2, 3, 4];
+
+function Grade() {
   const [clicked, setClicked] = useState([false, false, false, false, false]);
 
-  const handleStarClick = (e, index) => {
-    e.preventDefault();
+  const handleStarClick = index => {
     let clickStates = [...clicked];
     for (let i = 0; i < 5; i++) {
-      if (i <= index) clickStates[i] = true;
-      else clickStates[i] = false;
+      clickStates[i] = i <= index ? true : false;
     }
-
     setClicked(clickStates);
   };
 
-  console.log(clicked);
-
   return (
-    <GradeContainer>
-      <ReviewTitle />
-      <BsStarContainer>
-        <BsStarMargin>
-          {clicked[0] ? (
-            <BsStarFill onClick={e => handleStarClick(e, 0)} />
-          ) : (
-            <BsStar onClick={e => handleStarClick(e, 0)} />
-          )}
-        </BsStarMargin>
-        <BsStarMargin>
-          {clicked[1] ? (
-            <BsStarFill onClick={e => handleStarClick(e, 1)} />
-          ) : (
-            <BsStar onClick={e => handleStarClick(e, 1)} />
-          )}
-        </BsStarMargin>
-        <BsStarMargin>
-          {clicked[2] ? (
-            <BsStarFill onClick={e => handleStarClick(e, 2)} />
-          ) : (
-            <BsStar onClick={e => handleStarClick(e, 2)} />
-          )}
-        </BsStarMargin>
-        <BsStarMargin>
-          {clicked[3] ? (
-            <BsStarFill onClick={e => handleStarClick(e, 3)} />
-          ) : (
-            <BsStar onClick={e => handleStarClick(e, 3)} />
-          )}
-        </BsStarMargin>
-        <BsStarMargin>
-          {clicked[4] ? (
-            <BsStarFill onClick={e => handleStarClick(e, 4)} />
-          ) : (
-            <BsStar onClick={e => handleStarClick(e, 4)} />
-          )}
-        </BsStarMargin>
-      </BsStarContainer>
-    </GradeContainer>
+    <Wrap>
+      <RatingText>평가하기</RatingText>
+      <Stars>
+        {ARRAY.map((el, idx) => {
+          return (
+            <FaStar
+              key={idx}
+              size="50"
+              onClick={() => handleStarClick(el)}
+              className={clicked[el] && 'blackStar'}
+            />
+          );
+        })}
+      </Stars>
+    </Wrap>
   );
-};
-const GradeContainer = styled.div`
-  width: 500px;
-  margin: 10px;
-`;
-
-const BsStarContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`;
-
-const BsStarMargin = styled.div`
-  margin: 0px 3px;
-`;
+}
 
 export default Grade;
+
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding-top: 15px;
+`;
+
+const RatingText = styled.div`
+  color: #787878;
+  font-size: 12px;
+  font-weight: 400;
+`;
+
+const Stars = styled.div`
+  display: flex;
+  padding-top: 5px;
+
+  & svg {
+    color: gray;
+    cursor: pointer;
+  }
+
+  :hover svg {
+    color: #000000;
+  }
+
+  & svg:hover ~ svg {
+    color: gray;
+  }
+
+  .blackStar {
+    color: #000000;
+  }
+`;

--- a/src/components/ReviewTitle.jsx
+++ b/src/components/ReviewTitle.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+const ReviewTitle = ({ titleName = '평점' }) => {
+  return <Title>{titleName}</Title>;
+};
+
+const Title = styled.div`
+  font-size: 20px;
+  font-weight: bold;
+  margin: 10px 0px;
+`;
+
+ReviewTitle.propTypes = {
+  titleName: PropTypes.string,
+};
+
+export default ReviewTitle;


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] react-icons  추가

### 반영 브랜치
feat/Grade -> develop

### 변경 사항
>hover나 클릭시 평점 동작 


<img width="336" alt="image" src="https://user-images.githubusercontent.com/59253551/158140172-7e56bd19-e354-49b3-9ebd-cc441c75a535.png">

<img width="305" alt="image" src="https://user-images.githubusercontent.com/59253551/158140179-202f5a74-eee0-4994-9e16-750743e1a035.png">

### 나중에 가능하면 추가할 기능
icons에 대해서 0.5점 기능은 여러 방법을 찾았지만 해법이 제대로 된 것이 없다. 

첫번째는 5개가 전부 채워진 별 이미지와 전부 채워지지않은 별 이미지를 사용한 방법이 있을 것 같고
[링크](https://velog.io/@yshh0514/React-%EB%B3%84%EC%A0%90-%EA%B8%B0%EB%8A%A5-%EA%B5%AC%ED%98%84)

두번째는 5개가 전부 채워진것과 채워지지않은 것을 포함한 이미지를 통해 사용하는 것이 있는 것 같다.
[링크](https://m.blog.naver.com/PostView.naver?isHttpsRedirect=true&blogId=inyoung313&logNo=220618323942)

